### PR TITLE
Using Level-Party

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A native node 8 promise wrapper around the `level` database.",
   "main": "index.js",
   "dependencies": {
-    "level": "^1.7.0"
+    "level-party": "^3.0.4"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
level-party adds the ability to use leveldb across multiple node instances (like sharding). Howeve, it also removes `.destroy()` and `.repair()` which is sad, but necessary.